### PR TITLE
Promised connect event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 
 matrix:
   include:
+    - node_js: "4"
+      addons:
+        postgresql: "9.1"
     - node_js: "6"
       addons:
         postgresql: "9.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-
+dist: precise
 matrix:
   include:
     - node_js: "4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: node_js
 
 matrix:
   include:
-    - node_js: "4"
-      addons:
-        postgresql: "9.1"
     - node_js: "6"
       addons:
         postgresql: "9.4"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A connection pool for node-postgres
 
 ## install
 ```sh
-npm i pg-pool pg 
+npm i pg-pool pg
 ```
 
 ## use

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A connection pool for node-postgres
 
 ## install
 ```sh
-npm i pg-pool pg
+npm i pg-pool pg 
 ```
 
 ## use
@@ -78,7 +78,7 @@ const pool = new Pool(config);
     ssl: true
   }
 */
-``` 
+```
 
 ### acquire clients with a promise
 

--- a/index.js
+++ b/index.js
@@ -106,7 +106,11 @@ Pool.prototype._create = function (cb) {
         this.log('came back from connect')
         cb(null, client)
       })
-      .catch(err => cb(err, null))
+      .catch(err => {
+        this.log('connect listener error:', err)
+        this.pool.destroy(client)
+        cb(err, null)
+      })
   }.bind(this))
 }
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var genericPool = require('generic-pool')
 var util = require('util')
-var EventEmitter = require('events').EventEmitter
 var objectAssign = require('object-assign')
+var EventEmitter = require('promise-events')
 
 // there is a bug in the generic pool where it will not recreate
 // destroyed workers (even if there is waiting work to do) unless
@@ -27,7 +27,7 @@ var Pool = module.exports = function (options, Client) {
   if (!(this instanceof Pool)) {
     return new Pool(options, Client)
   }
-  EventEmitter.call(this)
+
   this.options = objectAssign({}, options)
   this.log = this.options.log || function () { }
   this.Client = this.options.Client || Client || require('pg').Client
@@ -97,11 +97,16 @@ Pool.prototype._create = function (cb) {
     if (err) {
       this.log('client connection error:', err)
       cb(err, null)
-    } else {
-      this.log('client connected')
-      this.emit('connect', client)
-      cb(null, client)
+      return
     }
+
+    this.log('client connected')
+    this.emit('connect', client)
+      .then(() => {
+        this.log('came back from connect')
+        cb(null, client)
+      })
+      .catch(err => cb(err, null))
   }.bind(this))
 }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "generic-pool": "2.4.3",
-    "object-assign": "4.1.0"
+    "object-assign": "4.1.0",
+    "promise-events": "^0.1.3"
   }
 }

--- a/test/events.js
+++ b/test/events.js
@@ -22,11 +22,13 @@ describe('events', function () {
     })
   })
 
-  it('waits on connect until finished', function (done) {
+  it.only('waits on connect until finished', function (done) {
     var pool = new Pool()
     var emittedClient = false
     pool.on('connect', function (client) {
-      return client.query('SELECT now()')
+      return new Promise(resolve => {
+        setTimeout(resolve, 50)
+      })
       .then(() => {
         emittedClient = client
       })
@@ -41,21 +43,17 @@ describe('events', function () {
     })
   })
 
-  it('catch error on connect', function (done) {
+  it('catch error on connect listener', function (done) {
     var pool = new Pool()
-    var connectingErr = 'connecting error'
+    var listenerErr = 'Listener error'
     pool.on('connect', function (client) {
-      return client.query('SELECT now()')
-      .then(() => {
-        throw new Error(connectingErr)
-      })
+      throw new Error(listenerErr)
     })
 
     pool.connect(function (err, client, release) {
       if (!err) return done('did not catch the error')
-      release()
       pool.end()
-      expect(err.message).to.equal(connectingErr)
+      expect(err.message).to.equal(listenerErr)
       done()
     })
   })

--- a/test/events.js
+++ b/test/events.js
@@ -22,7 +22,7 @@ describe('events', function () {
     })
   })
 
-  it.only('waits on connect until finished', function (done) {
+  it('waits on connect until finished', function (done) {
     var pool = new Pool()
     var emittedClient = false
     pool.on('connect', function (client) {


### PR DESCRIPTION
According to documentation (https://node-postgres.com/api/pool) the pool 'onConnect' event is the place to run setup commands on a client. Unfortunately the _create function who's emitting the connect event does not wait on the connect to finish its work, which makes it impossible to run set up functionality like setting query group on the client or any async functionality for that matter.
The new code implements 'promise-events' as the EventEmitter. It inherits Node's built-in EventEmitter interface, except that selected methods are overridden to return a promise.
(https://www.npmjs.com/package/promise-events)
I've also added tests to check that we wait on the connect, plus catching an error if there is one.